### PR TITLE
Repair for HA 2026.4.4 Update

### DIFF
--- a/src/HADashboard.ts
+++ b/src/HADashboard.ts
@@ -184,7 +184,6 @@ export class HADashboard extends LitElement {
             margin: 7px 0;
             min-height: calc(100% - 2 * 7px);
             display: flex;
-            flex-direction: column;
           }
 
           .sidebar > * {


### PR DESCRIPTION
Setting flex-direction for the sidebar class after HA 2026.4.4 sets the height of all children to 0. Removed this property in order to keep the card functioning.